### PR TITLE
Shortened names. Updated for breaking changes in last imgui updates

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,11 +1,11 @@
 import json
 from typing import List
 from model.dear_bindings.interfaces import IBinding
-from model.dear_bindings.binding import DearBindingNew
-from model.dear_bindings.struct import DearBindingsStructNew
-from model.dear_bindings.function import DearBindingsFunctionNew
-from model.dear_bindings.db_type import DearBindingsTypeNew, Kind, Kinds
-from model.dear_bindings.argument import DearBindingsArgumentNew
+from model.dear_bindings.binding import Binding
+from model.dear_bindings.struct import Struct
+from model.dear_bindings.function import Function
+from model.dear_bindings.db_type import _Type, Kind, Kinds
+from model.dear_bindings.argument import Argument
 from model.comments import Comments
 
 
@@ -32,128 +32,128 @@ modules: List[IBinding] = []
 # core
 with open("external/dear_bindings/cimgui.json") as f:
     modules.append(
-        DearBindingNew.from_json(json.load(f), "cimgui.h", defines)
+        Binding.from_json(json.load(f), "cimgui.h", defines)
     )
 
 # glfw
 with open("core/backends/glfw.json") as f:
-    glfw = DearBindingNew(
+    glfw = Binding(
         enums=[],
         typedefs=[],
         structs=[
-            DearBindingsStructNew("GLFWwindow",  []),
-            DearBindingsStructNew("GLFWmonitor", []),
+            Struct("GLFWwindow",  []),
+            Struct("GLFWmonitor", []),
         ],
         functions=[
-            DearBindingsFunctionNew("ImGui_ImplGlfw_InitForOpenGL",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplGlfw_InitForOpenGL",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [
-                    DearBindingsArgumentNew("window",            DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("install_callbacks", DearBindingsTypeNew("bool",        Kind(Kinds.Builtin, "bool"))),
+                    Argument("window",            _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("install_callbacks", _Type("bool",        Kind(Kinds.Builtin, "bool"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_InitForVulkan",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplGlfw_InitForVulkan",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [
-                    DearBindingsArgumentNew("window",            DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("install_callbacks", DearBindingsTypeNew("bool",        Kind(Kinds.Builtin, "bool"))),
+                    Argument("window",            _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("install_callbacks", _Type("bool",        Kind(Kinds.Builtin, "bool"))),
                 ],
                 Comments([], None)
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_InitForOther",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplGlfw_InitForOther",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [
-                    DearBindingsArgumentNew("window",            DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("install_callbacks", DearBindingsTypeNew("bool",        Kind(Kinds.Builtin, "bool"))),
+                    Argument("window",            _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("install_callbacks", _Type("bool",        Kind(Kinds.Builtin, "bool"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_Shutdown",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_Shutdown",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_NewFrame",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_NewFrame",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_InstallCallbacks",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_InstallCallbacks",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("window", _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_RestoreCallbacks",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_RestoreCallbacks",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("window", _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_SetCallbacksChainForAllWindows",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_SetCallbacksChainForAllWindows",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("chain_for_all_windows", DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool"))),
+                    Argument("chain_for_all_windows", _Type("bool", Kind(Kinds.Builtin, "bool"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_WindowFocusCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_WindowFocusCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window",  DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("focused", DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("window",  _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("focused", _Type("int",         Kind(Kinds.Builtin, "int"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_CursorEnterCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_CursorEnterCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window",  DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("entered", DearBindingsTypeNew("double",      Kind(Kinds.Builtin, "double"))),
+                    Argument("window",  _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("entered", _Type("double",      Kind(Kinds.Builtin, "double"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_CursorPosCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_CursorPosCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("x",      DearBindingsTypeNew("double",      Kind(Kinds.Builtin, "double"))),
-                    DearBindingsArgumentNew("y",      DearBindingsTypeNew("double",      Kind(Kinds.Builtin, "double"))),
+                    Argument("window", _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("x",      _Type("double",      Kind(Kinds.Builtin, "double"))),
+                    Argument("y",      _Type("double",      Kind(Kinds.Builtin, "double"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_MouseButtonCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_MouseButtonCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("button", DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
-                    DearBindingsArgumentNew("action", DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
-                    DearBindingsArgumentNew("mods",   DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("window", _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("button", _Type("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("action", _Type("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("mods",   _Type("int",         Kind(Kinds.Builtin, "int"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_ScrollCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_ScrollCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window",  DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("xoffset", DearBindingsTypeNew("double",      Kind(Kinds.Builtin, "double"))),
-                    DearBindingsArgumentNew("yoffset", DearBindingsTypeNew("double",      Kind(Kinds.Builtin, "double"))),
+                    Argument("window",  _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("xoffset", _Type("double",      Kind(Kinds.Builtin, "double"))),
+                    Argument("yoffset", _Type("double",      Kind(Kinds.Builtin, "double"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_KeyCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_KeyCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window",   DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("key",      DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
-                    DearBindingsArgumentNew("scancode", DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
-                    DearBindingsArgumentNew("action",   DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
-                    DearBindingsArgumentNew("mods",     DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("window",   _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("key",      _Type("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("scancode", _Type("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("action",   _Type("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("mods",     _Type("int",         Kind(Kinds.Builtin, "int"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_CharCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_CharCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*",  Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("c",      DearBindingsTypeNew("unsigned int", Kind(Kinds.Builtin, "unsigned int"))),
+                    Argument("window", _Type("GLFWwindow*",  Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("c",      _Type("unsigned int", Kind(Kinds.Builtin, "unsigned int"))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplGlfw_MonitorCallback",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplGlfw_MonitorCallback",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("window", DearBindingsTypeNew("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
-                    DearBindingsArgumentNew("event",  DearBindingsTypeNew("int",         Kind(Kinds.Builtin, "int"))),
+                    Argument("window", _Type("GLFWwindow*", Kind(Kinds.Pointer, Kind(Kinds.User, "GLFWwindow")))),
+                    Argument("event",  _Type("int",         Kind(Kinds.Builtin, "int"))),
                 ],
             ),
         ],
@@ -164,45 +164,45 @@ with open("core/backends/glfw.json") as f:
 
 # opengl3
 with open("core/backends/opengl3.json") as f:
-    opengl3 = DearBindingNew(
+    opengl3 = Binding(
         enums=[],
         typedefs=[],
         structs=[],
         functions=[
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_Init",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplOpenGL3_Init",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [
-                    DearBindingsArgumentNew("glsl_version", DearBindingsTypeNew("const char*", Kind(Kinds.Pointer, Kind(Kinds.Builtin, "char", is_const=True))), default_value="None"),
+                    Argument("glsl_version", _Type("const char*", Kind(Kinds.Pointer, Kind(Kinds.Builtin, "char", is_const=True))), default_value="None"),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_Shutdown",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplOpenGL3_Shutdown",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_NewFrame",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplOpenGL3_NewFrame",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_RenderDrawData",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplOpenGL3_RenderDrawData",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [
-                    DearBindingsArgumentNew("draw_data", DearBindingsTypeNew("ImDrawData*", Kind(Kinds.Pointer, Kind(Kinds.User, "ImDrawData")))),
+                    Argument("draw_data", _Type("ImDrawData*", Kind(Kinds.Pointer, Kind(Kinds.User, "ImDrawData")))),
                 ],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_CreateFontsTexture",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplOpenGL3_CreateFontsTexture",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_DestroyFontsTexture",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplOpenGL3_DestroyFontsTexture",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_CreateDeviceObjects",
-                DearBindingsTypeNew("bool", Kind(Kinds.Builtin, "bool")),
+            Function("ImGui_ImplOpenGL3_CreateDeviceObjects",
+                _Type("bool", Kind(Kinds.Builtin, "bool")),
                 [],
             ),
-            DearBindingsFunctionNew("ImGui_ImplOpenGL3_DestroyDeviceObjects",
-                DearBindingsTypeNew("void", Kind(Kinds.Builtin, "void")),
+            Function("ImGui_ImplOpenGL3_DestroyDeviceObjects",
+                _Type("void", Kind(Kinds.Builtin, "void")),
                 [],
             ),
         ],

--- a/src/core/core.pyx
+++ b/src/core/core.pyx
@@ -7,7 +7,7 @@ import cython
 import array
 from collections import namedtuple
 from cython.operator import dereference
-from typing import Callable, Any, Sequence, Tuple, NamedTuple
+from typing import Callable, Any, Sequence, Tuple, NamedTuple, Optional
 
 cimport ccimgui
 from libcpp cimport bool
@@ -8594,31 +8594,33 @@ def show_font_selector(label: str):
 # [End Function]
 
 # [Function]
-# ?use_template(False)
-# ?active(False)
-# ?invisible(False)
-# ?custom_comment_only(False)
-# ?returns(None)
-# def show_id_stack_tool_window():
-#     """
-#     Implied p_open = null
-#     """
-#     ccimgui.ImGui_ShowIDStackToolWindow()
-# [End Function]
-
-# [Function]
-# ?use_template(False)
+# ?use_template(True)
 # ?active(True)
 # ?invisible(False)
 # ?custom_comment_only(False)
 # ?returns(None)
-def show_id_stack_tool_window_ex(p_open: Bool=None):
+def show_id_stack_tool_window(p_open: Bool=None):
     """
     Create stack tool window. hover items with mouse to query information about the source of their unique id.
     """
     ccimgui.ImGui_ShowIDStackToolWindowEx(
         Bool.ptr(p_open)
     )
+# [End Function]
+
+# [Function]
+# ?use_template(False)
+# ?active(False)
+# ?invisible(True)
+# ?custom_comment_only(False)
+# ?returns(None)
+# def show_id_stack_tool_window_ex(p_open: Bool=None):
+#     """
+#     Create stack tool window. hover items with mouse to query information about the source of their unique id.
+#     """
+#     ccimgui.ImGui_ShowIDStackToolWindowEx(
+#         Bool.ptr(p_open)
+#     )
 # [End Function]
 
 # [Function]
@@ -18434,21 +18436,6 @@ cdef class ImGuiIO:
     # ?invisible(False)
     # ?custom_comment_only(False)
     # ?returns(None)
-    # def clear_input_characters(self: ImGuiIO):
-    #     """
-    #     [internal] clear the text input buffer manually
-    #     """
-    #     ccimgui.ImGuiIO_ClearInputCharacters(
-    #         self._ptr
-    #     )
-    # [End Method]
-
-    # [Method]
-    # ?use_template(False)
-    # ?active(False)
-    # ?invisible(False)
-    # ?custom_comment_only(False)
-    # ?returns(None)
     # def clear_input_keys(self: ImGuiIO):
     #     """
     #     Clear current keyboard/mouse/gamepad state + current frame text input buffer. equivalent to releasing all keys/buttons.
@@ -19264,30 +19251,32 @@ cdef class ImGuiListClipper:
 
     # [Method]
     # ?use_template(False)
-    # ?active(False)
+    # ?active(True)
     # ?invisible(False)
-    # ?custom_comment_only(False)
+    # ?custom_comment_only(True)
     # ?returns(None)
-    # def include_item_by_index(self: ImGuiListClipper, item_index: int):
-    #     """
-    #     Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
-    #     (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
-    #     """
-    #     ccimgui.ImGuiListClipper_IncludeItemByIndex(
-    #         self._ptr,
-    #         item_index
-    #     )
+    def include_item_by_index(self: ImGuiListClipper, item_index: int):
+        """
+        Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
+        (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
+        """
+        ccimgui.ImGuiListClipper_IncludeItemByIndex(
+            self._ptr,
+            item_index
+        )
     # [End Method]
 
     # [Method]
     # ?use_template(False)
     # ?active(True)
     # ?invisible(False)
-    # ?custom_comment_only(False)
+    # ?custom_comment_only(True)
     # ?returns(None)
     def include_items_by_index(self: ImGuiListClipper, item_begin: int, item_end: int):
         """
         Item_end is exclusive e.g. use (42, 42+1) to make item 42 never clipped.
+
+        [#6424](https://github.com/ocornut/imgui/issues/6424) JaedanC Easteregg. This is my suggestion!
         """
         ccimgui.ImGuiListClipper_IncludeItemsByIndex(
             self._ptr,

--- a/src/core/core_generated.pyx
+++ b/src/core/core_generated.pyx
@@ -7,7 +7,7 @@ import cython
 import array
 from collections import namedtuple
 from cython.operator import dereference
-from typing import Callable, Any, Sequence, Tuple, NamedTuple
+from typing import Callable, Any, Sequence, Tuple, NamedTuple, Optional
 
 cimport ccimgui
 from libcpp cimport bool

--- a/src/core/core_template.pyx
+++ b/src/core/core_template.pyx
@@ -7,7 +7,7 @@ import cython
 import array
 from collections import namedtuple
 from cython.operator import dereference
-from typing import Callable, Any, Sequence, Tuple, NamedTuple
+from typing import Callable, Any, Sequence, Tuple, NamedTuple, Optional
 
 cimport ccimgui
 from libcpp cimport bool
@@ -8594,22 +8594,24 @@ def show_font_selector(label: str):
 # [End Function]
 
 # [Function]
-# ?use_template(False)
-# ?active(False)
+# ?use_template(True)
+# ?active(True)
 # ?invisible(False)
 # ?custom_comment_only(False)
 # ?returns(None)
-def show_id_stack_tool_window():
+def show_id_stack_tool_window(p_open: Bool=None):
     """
-    Implied p_open = null
+    Create stack tool window. hover items with mouse to query information about the source of their unique id.
     """
-    ccimgui.ImGui_ShowIDStackToolWindow()
+    ccimgui.ImGui_ShowIDStackToolWindowEx(
+        Bool.ptr(p_open)
+    )
 # [End Function]
 
 # [Function]
 # ?use_template(False)
-# ?active(True)
-# ?invisible(False)
+# ?active(False)
+# ?invisible(True)
 # ?custom_comment_only(False)
 # ?returns(None)
 def show_id_stack_tool_window_ex(p_open: Bool=None):
@@ -18434,21 +18436,6 @@ cdef class ImGuiIO:
     # ?invisible(False)
     # ?custom_comment_only(False)
     # ?returns(None)
-    def clear_input_characters(self: ImGuiIO):
-        """
-        [internal] clear the text input buffer manually
-        """
-        ccimgui.ImGuiIO_ClearInputCharacters(
-            self._ptr
-        )
-    # [End Method]
-
-    # [Method]
-    # ?use_template(False)
-    # ?active(False)
-    # ?invisible(False)
-    # ?custom_comment_only(False)
-    # ?returns(None)
     def clear_input_keys(self: ImGuiIO):
         """
         Clear current keyboard/mouse/gamepad state + current frame text input buffer. equivalent to releasing all keys/buttons.
@@ -19264,9 +19251,9 @@ cdef class ImGuiListClipper:
 
     # [Method]
     # ?use_template(False)
-    # ?active(False)
+    # ?active(True)
     # ?invisible(False)
-    # ?custom_comment_only(False)
+    # ?custom_comment_only(True)
     # ?returns(None)
     def include_item_by_index(self: ImGuiListClipper, item_index: int):
         """
@@ -19283,11 +19270,13 @@ cdef class ImGuiListClipper:
     # ?use_template(False)
     # ?active(True)
     # ?invisible(False)
-    # ?custom_comment_only(False)
+    # ?custom_comment_only(True)
     # ?returns(None)
     def include_items_by_index(self: ImGuiListClipper, item_begin: int, item_end: int):
         """
         Item_end is exclusive e.g. use (42, 42+1) to make item 42 never clipped.
+
+        [#6424](https://github.com/ocornut/imgui/issues/6424) JaedanC Easteregg. This is my suggestion!
         """
         ccimgui.ImGuiListClipper_IncludeItemsByIndex(
             self._ptr,

--- a/src/model/dear_bindings/argument.py
+++ b/src/model/dear_bindings/argument.py
@@ -3,11 +3,11 @@ from typing import Optional
 from ..comments import Comments, parse_comment
 from . import safe_python_name
 from .interfaces import IArgument, IType
-from .db_type import DearBindingsTypeNew
+from .db_type import _Type
 import re
 
 
-class DearBindingsArgumentNew(IArgument):
+class Argument(IArgument):
     def from_json(argument_json: dict) -> IArgument:
         """Argument
         {
@@ -28,7 +28,7 @@ class DearBindingsArgumentNew(IArgument):
         """
         name = safe_python_name(argument_json["name"])
         assert not argument_json.get("is_varargs"), "Python does not support is_varargs: {}".format(name)
-        _type: IType = DearBindingsTypeNew.from_json(argument_json["type"])
+        _type: IType = _Type.from_json(argument_json["type"])
         comments: Comments = parse_comment(argument_json)
 
         default_lookup = {
@@ -56,7 +56,7 @@ class DearBindingsArgumentNew(IArgument):
             if _type.with_no_const_or_sign() == "float":
                 default_value = default_value.replace("f", "")
         
-        return DearBindingsArgumentNew(name, _type, comments, default_value)
+        return Argument(name, _type, comments, default_value)
 
     def __init__(self, name: str, _type: IType, comments: Comments = None, default_value=None):
         self.name = name

--- a/src/model/dear_bindings/db_type.py
+++ b/src/model/dear_bindings/db_type.py
@@ -144,7 +144,7 @@ class FunctionPointer:
         )
 
 
-class DearBindingsTypeNew(IType):
+class _Type(IType):
     def from_json(type_json: dict):
         """Pointer
         {
@@ -282,7 +282,7 @@ class DearBindingsTypeNew(IType):
         declaration: str = type_json["declaration"]
         is_function_pointer = "type_details" in type_json
         kind: Kind = Kind.from_json(type_json["description"], is_function_pointer)
-        return DearBindingsTypeNew(declaration, kind)
+        return _Type(declaration, kind)
 
     def __init__(self, declaration: str, kind: Kind):
         self.declaration = declaration

--- a/src/model/dear_bindings/enum.py
+++ b/src/model/dear_bindings/enum.py
@@ -28,12 +28,12 @@ class Element(IEnumElement):
         return pythonise_string(self.name_omitted_imgui_prefix()).upper()
 
 
-class DearBindingsEnumNew(IEnum):
+class _Enum(IEnum):
     def from_json(enum_json: dict) -> IEnum:
         name = enum_json["name"]
         elements = [Element.from_json(e) for e in enum_json["elements"]]
         comments = parse_comment(enum_json)
-        return DearBindingsEnumNew(name, elements, comments)
+        return _Enum(name, elements, comments)
 
     def __init__(self, name: str, elements: List[IEnumElement], comments: Comments):
         self.name = name

--- a/src/model/dear_bindings/function.py
+++ b/src/model/dear_bindings/function.py
@@ -2,11 +2,11 @@ from io import StringIO
 from typing import List
 from ..comments import Comments, parse_comment
 from .interfaces import IFunction, IType, IArgument
-from .db_type import DearBindingsTypeNew
-from .argument import DearBindingsArgumentNew
+from .db_type import _Type
+from .argument import Argument
 
 
-class DearBindingsFunctionNew(IFunction):
+class Function(IFunction):
     def from_json(function_json: dict) -> IFunction:
         """Function
         {
@@ -53,15 +53,15 @@ class DearBindingsFunctionNew(IFunction):
         },
         """
         name: str = function_json["name"]
-        return_type: IType = DearBindingsTypeNew.from_json(function_json["return_type"])
+        return_type: IType = _Type.from_json(function_json["return_type"])
         # Ignore any Cython unsupported arguments
         arguments: List[IArgument] = []
         for argument in function_json["arguments"]:
             if argument["is_varargs"] or argument.get("type", {}).get("declaration") == "va_list":
                 continue
-            arguments.append(DearBindingsArgumentNew.from_json(argument))
+            arguments.append(Argument.from_json(argument))
         comments: Comments = parse_comment(function_json)
-        return DearBindingsFunctionNew(name, return_type, arguments, comments)
+        return Function(name, return_type, arguments, comments)
 
     def __init__(self, name: str, return_type: IType, arguments: List[IArgument], comments: Comments = None):
         self.name = name

--- a/src/model/dear_bindings/struct.py
+++ b/src/model/dear_bindings/struct.py
@@ -4,11 +4,11 @@ from typing import List
 from ..comments import Comments, parse_comment
 from . import safe_python_name
 from .interfaces import IStruct, IType, IField, IFunction
-from .db_type import DearBindingsTypeNew
+from .db_type import _Type
 
 
 
-class DearBindingsStructField(IField):
+class Field(IField):
     def from_json(field_json: dict) -> IField:
         """Field
         {
@@ -118,9 +118,9 @@ class DearBindingsStructField(IField):
             }
         """
         name: str = safe_python_name(field_json["name"])
-        _type: IType = DearBindingsTypeNew.from_json(field_json["type"])
+        _type: IType = _Type.from_json(field_json["type"])
         comments: Comments = parse_comment(field_json)
-        return DearBindingsStructField(name, _type, comments)
+        return Field(name, _type, comments)
 
     def __init__(self, name: str, _type: IType, comments: Comments = None):
         self.name = name
@@ -145,7 +145,7 @@ class DearBindingsStructField(IField):
         return self._type
 
 
-class DearBindingsStructNew(IStruct):
+class Struct(IStruct):
     def from_json(struct_json: dict) -> IStruct:
         """Struct
         {
@@ -154,9 +154,9 @@ class DearBindingsStructNew(IStruct):
         }
         """
         name: str = struct_json["name"]
-        fields: List[IField] = [DearBindingsStructField.from_json(f) for f in struct_json["fields"]]
+        fields: List[IField] = [Field.from_json(f) for f in struct_json["fields"]]
         comments: Comments = parse_comment(struct_json)
-        return DearBindingsStructNew(name, fields, comments)
+        return Struct(name, fields, comments)
 
     def __init__(self, name: str, fields: List[IField], comments: Comments = None):
         self.name = name

--- a/src/model/dear_bindings/typedef.py
+++ b/src/model/dear_bindings/typedef.py
@@ -1,11 +1,11 @@
 import textwrap
 from io import StringIO
-from .db_type import DearBindingsTypeNew
+from .db_type import _Type
 from .interfaces import ITypedef, HasComment, IType
 from ..comments import Comments, parse_comment
 
 
-class DearBindingsTypedefNew(ITypedef, HasComment):
+class Typedef(ITypedef, HasComment):
     def from_json(typedef_json: dict) -> ITypedef:
         """Typedef
         {
@@ -22,10 +22,10 @@ class DearBindingsTypedefNew(ITypedef, HasComment):
             }
         },
         """
-        base: IType = DearBindingsTypeNew.from_json(typedef_json["type"])
+        base: IType = _Type.from_json(typedef_json["type"])
         definition: str = typedef_json["name"]
         comments: Comments = parse_comment(typedef_json)
-        return DearBindingsTypedefNew(base, definition, comments)
+        return Typedef(base, definition, comments)
 
     def __init__(self, base: IType, definition: str, comments: Comments):
         self.base = base

--- a/src/model_creator.py
+++ b/src/model_creator.py
@@ -78,7 +78,7 @@ def to_pyi(
     base = textwrap.dedent('''
     # This file is auto-generated. If you need to edit this file then edit the
     # template this is created from instead.
-    from typing import Any, Callable, Tuple, List, Sequence
+    from typing import Any, Callable, Tuple, List, Sequence, Optional
     from PIL import Image
 
     FLT_MIN: float
@@ -525,7 +525,7 @@ def to_py(extension_name: str):
         h = image.height
 
         # create the texture in VRAM
-        texture: int = gl.glGenTextures(1)
+        texture: int = int(gl.glGenTextures(1))
         gl.glBindTexture(gl.GL_TEXTURE_2D, texture)
 
         # configure some texture settings

--- a/src/pygui/__init__.py
+++ b/src/pygui/__init__.py
@@ -17,7 +17,7 @@ def load_image(image: Image) -> int:
     h = image.height
 
     # create the texture in VRAM
-    texture: int = gl.glGenTextures(1)
+    texture: int = int(gl.glGenTextures(1))
     gl.glBindTexture(gl.GL_TEXTURE_2D, texture)
 
     # configure some texture settings

--- a/src/pygui/__init__.pyi
+++ b/src/pygui/__init__.pyi
@@ -1,6 +1,6 @@
 # This file is auto-generated. If you need to edit this file then edit the
 # template this is created from instead.
-from typing import Any, Callable, Tuple, List, Sequence
+from typing import Any, Callable, Tuple, List, Sequence, Optional
 from PIL import Image
 
 FLT_MIN: float
@@ -2888,13 +2888,7 @@ def show_font_selector(label: str) -> None:
     """
     pass
 
-# def show_id_stack_tool_window() -> None:
-#     """
-#     Implied p_open = null
-#     """
-#     pass
-
-def show_id_stack_tool_window_ex(p_open: Bool=None) -> None:
+def show_id_stack_tool_window(p_open: Bool=None) -> None:
     """
     Create stack tool window. hover items with mouse to query information about the source of their unique id.
     """
@@ -4654,12 +4648,6 @@ class ImGuiIO:
     #     """
     #     pass
 
-    # def clear_input_characters(self: ImGuiIO) -> None:
-    #     """
-    #     [internal] clear the text input buffer manually
-    #     """
-    #     pass
-
     # def clear_input_keys(self: ImGuiIO) -> None:
     #     """
     #     Clear current keyboard/mouse/gamepad state + current frame text input buffer. equivalent to releasing all keys/buttons.
@@ -4836,16 +4824,18 @@ class ImGuiListClipper:
         """
         pass
 
-    # def include_item_by_index(self: ImGuiListClipper, item_index: int) -> None:
-    #     """
-    #     Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
-    #     (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
-    #     """
-    #     pass
+    def include_item_by_index(self: ImGuiListClipper, item_index: int) -> None:
+        """
+        Call IncludeItemByIndex() or IncludeItemsByIndex() *BEFORE* first call to Step() if you need a range of items to not be clipped, regardless of their visibility.
+        (Due to alignment / padding of certain items it is possible that an extra item may be included on either end of the display range).
+        """
+        pass
 
     def include_items_by_index(self: ImGuiListClipper, item_begin: int, item_end: int) -> None:
         """
         Item_end is exclusive e.g. use (42, 42+1) to make item 42 never clipped.
+
+        [#6424](https://github.com/ocornut/imgui/issues/6424) JaedanC Easteregg. This is my suggestion!
         """
         pass
 

--- a/src/pygui_demo.py
+++ b/src/pygui_demo.py
@@ -99,7 +99,7 @@ class ExampleAppConsole:
 
         # Reserve enough left-over height for 1 separator + 1 input text
         footer_height_to_reserve = pygui.get_style().item_spacing[1] + pygui.get_frame_height_with_spacing()
-        if pygui.begin_child("ScrollingRegion", (0, -footer_height_to_reserve), False, pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR):
+        if pygui.begin_child("ScrollingRegion", (0, -footer_height_to_reserve), 0, pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR):
             if pygui.begin_popup_context_window():
                 if pygui.selectable("Clear"):
                     self.clear_log()
@@ -526,11 +526,11 @@ class ExampleAppDocuments:
                 if pygui.begin_popup_modal("Save?", None, pygui.WINDOW_FLAGS_ALWAYS_AUTO_RESIZE):
                     pygui.text("Save change to the following items?")
                     item_height = pygui.get_text_line_height_with_spacing()
-                    if pygui.begin_child_frame(pygui.get_id("pygui_frame"), (-pygui.FLT_MIN, 6.25 * item_height)):
+                    if pygui.begin_child(pygui.get_id("pygui_frame"), (-pygui.FLT_MIN, 6.25 * item_height), pygui.CHILD_FLAGS_FRAME_STYLE):
                         for n in range(len(ExampleAppDocuments.close_queue)):
                             if ExampleAppDocuments.close_queue[n].dirty:
                                 pygui.text(ExampleAppDocuments.close_queue[n].name)
-                        pygui.end_child_frame()
+                        pygui.end_child()
                     button_size = (pygui.get_font_size() * 7, 0)
                     if pygui.button("Yes", button_size):
                         for n in range(len(ExampleAppDocuments.close_queue)):
@@ -566,7 +566,7 @@ class demo:
     show_debug_log_window = pygui.Bool(False)
     show_font_selector = pygui.Bool(False)
     show_metrics_window = pygui.Bool(False)
-    show_stack_tool_window = pygui.Bool(False)
+    show_id_stack_tool_window = pygui.Bool(False)
     show_style_editor = pygui.Bool(False)
     show_style_selector = pygui.Bool(False)
     show_user_guide = pygui.Bool(False)
@@ -595,8 +595,8 @@ def pygui_demo_window():
         pygui.end()
     if demo.show_metrics_window:
         pygui.show_metrics_window(demo.show_metrics_window)
-    if demo.show_stack_tool_window:
-        pygui.show_stack_tool_window(demo.show_stack_tool_window)
+    if demo.show_id_stack_tool_window:
+        pygui.show_id_stack_tool_window(demo.show_id_stack_tool_window)
     if demo.show_style_editor:
         if pygui.begin("Style Editor", demo.show_style_editor):
             pygui.show_style_editor()
@@ -2052,9 +2052,9 @@ def show_demo_window_layout():
             names = ["Top", "25%", "Center", "75%", "Bottom"]
             pygui.text_unformatted(names[i])
 
-            child_flags = pygui.WINDOW_FLAGS_MENU_BAR if layout.enable_extra_decorations else 0
+            child_flags = pygui.CHILD_FLAGS_BORDER | (pygui.WINDOW_FLAGS_MENU_BAR if layout.enable_extra_decorations else 0)
             child_id = pygui.get_id(str(i))
-            child_is_visible = pygui.begin_child(str(child_id), (child_w, 200), True, child_flags)
+            child_is_visible = pygui.begin_child(str(child_id), (child_w, 200), child_flags)
             if pygui.begin_menu_bar():
                 pygui.text_unformatted("abc")
                 pygui.end_menu_bar()
@@ -2086,9 +2086,12 @@ def show_demo_window_layout():
         pygui.push_id("##HorizontalScrolling")
         for i in range(5):
             child_height = pygui.get_text_line_height() + style.scrollbar_size + style.window_padding[1] * 2
-            child_flags = pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR | (pygui.WINDOW_FLAGS_ALWAYS_VERTICAL_SCROLLBAR if layout.enable_extra_decorations else 0)
+            child_flags = pygui.CHILD_FLAGS_BORDER
+            window_flags = \
+                pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR | \
+                (pygui.WINDOW_FLAGS_ALWAYS_VERTICAL_SCROLLBAR if layout.enable_extra_decorations else 0)
             child_id = pygui.get_id(str(i))
-            child_is_visible = pygui.begin_child(str(child_id), (-100, child_height), True, child_flags)
+            child_is_visible = pygui.begin_child(str(child_id), (-100, child_height), child_flags, window_flags)
             if scroll_to_off:
                 pygui.set_scroll_x(layout.scroll_to_off_px.value)
             if scroll_to_pos:
@@ -2119,7 +2122,7 @@ def show_demo_window_layout():
         pygui.push_style_var(pygui.STYLE_VAR_FRAME_ROUNDING, 3)
         pygui.push_style_var(pygui.STYLE_VAR_FRAME_PADDING, (2, 1))
         scrolling_child_size = (0, pygui.get_frame_height_with_spacing() * 7 + 30)
-        pygui.begin_child("scrolling", scrolling_child_size, True, pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR)
+        pygui.begin_child("scrolling", scrolling_child_size, pygui.CHILD_FLAGS_BORDER, pygui.WINDOW_FLAGS_HORIZONTAL_SCROLLBAR)
         for line in range(layout.lines.value):
             # Display random stuff. For the sake of this trivial demo we are using basic Button() + SameLine()
             # If you want to create your own time line for a real application you may be better off manipulating
@@ -3682,7 +3685,7 @@ def show_random_extras():
 
     if pygui.tree_node("pygui.begin_child_id()"):
         new_id = pygui.get_id("begin_child_id()")
-        pygui.begin_child_id(new_id, (0, 260), True)
+        pygui.begin_child_id(new_id, (0, 260), pygui.CHILD_FLAGS_BORDER)
         if pygui.begin_table("split", 2, pygui.TABLE_FLAGS_RESIZABLE | pygui.TABLE_FLAGS_NO_SAVED_SETTINGS):
             for i in range(30):
                 pygui.table_next_column()
@@ -4023,7 +4026,7 @@ def show_random_extras():
         pygui.text_wrapped("Buffer Size: {}".format(rand.input_buffer.buffer_size))
 
         pygui.text("Events: {}".format(len(rand.input_buffer_log)))
-        if pygui.begin_child("Callback log", (400, pygui.get_text_line_height_with_spacing() * 10), True):
+        if pygui.begin_child("Callback log", (400, pygui.get_text_line_height_with_spacing() * 10), pygui.CHILD_FLAGS_BORDER):
             for i, event in enumerate(rand.input_buffer_log):
                 pygui.text("{}: {}".format(i, event))
             pygui.set_scroll_here_y(1)
@@ -4126,12 +4129,12 @@ def show_random_extras():
             rand.jump_to_cache = steps_showing
         pygui.text("1. Update on the frame you move the slider")
         pygui.text("2. Update every frame")
-        if pygui.begin_child("Steps Showing", (140, pygui.get_text_line_height_with_spacing() * 4), True):
+        if pygui.begin_child("Steps Showing", (140, pygui.get_text_line_height_with_spacing() * 4), pygui.CHILD_FLAGS_BORDER):
             for step in rand.jump_to_cache:
                 pygui.text("Showing {} -> {}".format(*step))
         pygui.end_child()
         pygui.same_line()
-        if pygui.begin_child("Steps Showing Live", (140, pygui.get_text_line_height_with_spacing() * 4), True):
+        if pygui.begin_child("Steps Showing Live", (140, pygui.get_text_line_height_with_spacing() * 4), pygui.CHILD_FLAGS_BORDER):
             for step in steps_showing:
                 pygui.text("Showing {} -> {}".format(*step))
         pygui.end_child()
@@ -4148,7 +4151,7 @@ def show_random_extras():
         ]
         rand.text_filter.draw()
         pygui.text("filter.is_active(): {}".format(rand.text_filter.is_active()))
-        if pygui.begin_child("Filtered items", (200, pygui.get_text_line_height_with_spacing() * 7), True):
+        if pygui.begin_child("Filtered items", (200, pygui.get_text_line_height_with_spacing() * 7), pygui.CHILD_FLAGS_BORDER):
             for item in items:
                 if not rand.text_filter.pass_filter(item):
                     continue
@@ -4270,7 +4273,7 @@ def show_random_extras():
         visible = None
         rect_visible_from_cursor = None
         rect_visible = None
-        if pygui.begin_child("My child", (500, pygui.get_text_line_height_with_spacing() * 6), True):
+        if pygui.begin_child("My child", (500, pygui.get_text_line_height_with_spacing() * 6), pygui.CHILD_FLAGS_BORDER):
             pygui.text("Some")
             pygui.text("Lines")
             pygui.text("Inside")
@@ -4321,7 +4324,7 @@ def show_random_extras():
                 pygui.get_frame_count()
             ))
 
-        if pygui.begin_child("##Log for keys", (400, pygui.get_text_line_height_with_spacing() * 10), True):
+        if pygui.begin_child("##Log for keys", (400, pygui.get_text_line_height_with_spacing() * 10), pygui.CHILD_FLAGS_BORDER):
             for event in rand.key_press_log:
                 pygui.text(event)
         pygui.end_child()
@@ -4348,7 +4351,7 @@ def show_random_extras():
         if pygui.is_mouse_released(pygui.MOUSE_BUTTON_LEFT):
             rand.mouse_press_log.append("pygui.is_mouse_released(pygui.MOUSE_BUTTON_LEFT)")
         pygui.text("Log for pygui.MOUSE_BUTTON_LEFT")
-        if pygui.begin_child("Log for pygui.MOUSE_BUTTON_LEFT", (400, pygui.get_text_line_height_with_spacing() * 5), True):
+        if pygui.begin_child("Log for pygui.MOUSE_BUTTON_LEFT", (400, pygui.get_text_line_height_with_spacing() * 5), pygui.CHILD_FLAGS_BORDER):
             for event in rand.mouse_press_log:
                 pygui.text(event)
         pygui.end_child()
@@ -4371,7 +4374,7 @@ def show_random_extras():
             is_collapsed = pygui.is_window_collapsed()
             pygui.end()
         
-        if pygui.begin_child("#window log", (400, pygui.get_text_line_height_with_spacing() * 5), True):
+        if pygui.begin_child("#window log", (400, pygui.get_text_line_height_with_spacing() * 5), pygui.CHILD_FLAGS_BORDER):
             for event in rand.window_log:
                 pygui.text(event)
         pygui.end_child()
@@ -4728,6 +4731,7 @@ def show_menu_bar():
             if pygui.menu_item("Cut", "CTRL+X"): pass
             if pygui.menu_item("Copy", "CTRL+C"): pass
             if pygui.menu_item("Paste", "CTRL+V"): pass
+            if pygui.menu_item("No Shortcut", None): pass
             pygui.end_menu()
         if pygui.begin_menu("Examples"):
             pygui.menu_item_bool_ptr("Console", None, demo.show_app_console)
@@ -4739,7 +4743,7 @@ def show_menu_bar():
             pygui.menu_item_bool_ptr("Debug Log", None, demo.show_debug_log_window)
             pygui.menu_item_bool_ptr("Font Selector", None, demo.show_font_selector)
             pygui.menu_item_bool_ptr("Metrics/Debugger", None, demo.show_metrics_window)
-            pygui.menu_item_bool_ptr("Stack Tool", None, demo.show_stack_tool_window)
+            pygui.menu_item_bool_ptr("Stack Tool", None, demo.show_id_stack_tool_window)
             pygui.menu_item_bool_ptr("Style Editor", None, demo.show_style_editor)
             pygui.menu_item_bool_ptr("Style Selector", None, demo.show_style_selector)
             pygui.menu_item_bool_ptr("User guide", None, demo.show_user_guide)


### PR DESCRIPTION
1. Renamed the pxd parsing classes to be shorter
2. Updated the pygui_demo.py to accommodate breaking changes in the latest imgui releases.

See <https://github.com/ocornut/imgui/releases>